### PR TITLE
Update harness to add Inside Story tab

### DIFF
--- a/assets/harness.css
+++ b/assets/harness.css
@@ -14,11 +14,13 @@ h1 {
     padding: 1em;
 }
 
-.info-page {
+.info-page,
+.story-page {
     border: 1px solid #3c3c3c;
     border-top: 0;
-    display: none;
     padding: 1em;
+    position: absolute;
+    visibility: hidden;
 }
 
 .try-page {

--- a/assets/harness.js
+++ b/assets/harness.js
@@ -21,12 +21,21 @@ define(['jquery'], function($) {
         $('.info-button').click(function() {
             $('.info-page').addClass('active');
             $('.try-page').removeClass('active');
+            $('.story-page').removeClass('active');
+            notifyPilot('hide');
+        });
+
+        $('.story-button').click(function() {
+            $('.info-page').removeClass('active');
+            $('.try-page').removeClass('active');
+            $('.story-page').addClass('active');
             notifyPilot('hide');
         });
 
         $('.try-button').click(function() {
             $('.try-page').addClass('active');
             $('.info-page').removeClass('active');
+            $('.story-page').removeClass('active');
             notifyPilot('show');
         });
 
@@ -50,6 +59,9 @@ define(['jquery'], function($) {
                 case 'heightChange':
                     handleHeightChange(event);
                     break;
+                case 'showInsideStory':
+                    handleShowInsideStory(event);
+                    break;
             }
         }
 
@@ -57,6 +69,10 @@ define(['jquery'], function($) {
             if (event.desiredHeight !== undefined) {
                 $(iframe).height(event.desiredHeight);
             }
+        }
+
+        function handleShowInsideStory() {
+            $('.story-button').click();
         }
 
         window.addEventListener('message', receiveMessage, false);

--- a/index.html
+++ b/index.html
@@ -48,8 +48,9 @@
 <div class="Page" role="main">
   <div class="container">
     <div class="row">
-      <div class="col-xs-6 info-button taster-tab">Info</div>
-      <div class="col-xs-6 try-button taster-tab">Try</div>
+      <div class="col-xs-4 info-button taster-tab">Info</div>
+      <div class="col-xs-4 story-button taster-tab">Inside Story</div>
+      <div class="col-xs-4 try-button taster-tab">Try</div>
     </div>
     <div class="row info-page active">
       <h2 class="PageHeader-title">Info Page</h2>
@@ -64,6 +65,12 @@
         sent by your application and will
         <a href="https://confluence.dev.bbc.co.uk/display/PROTOALPHA/Pilot+Initialisation+query+strings">initialise it
         correctly based on the hashbang parameter passed in the URL</a>.
+      </p>
+    </div>
+    <div class="row story-page">
+      <h2 class="PageHeader-title">Inside Story Page</h2>
+      <p class="PageHeader-description">
+        This is where the pilot will be explained, so that the auidence gets to read the inside story on how and why and by whom the pilot was built
       </p>
     </div>
   </div>


### PR DESCRIPTION
The test harness has been updated so that pilots can test the integration of a new Taster API call to hide the pilot and display the inside story.
